### PR TITLE
replaces 'nx affected' with always building so the DIST content alway…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         shell: bash
 
       - name: Build affected
-        run: npx nx affected -t build --base=origin/main --head=HEAD
+        run: npx nx run-many --target=build --all --base=origin/main --head=HEAD
         shell: bash
 
       - name: Publish packages


### PR DESCRIPTION
…s be generated and published