### PR TITLE
IS-323: ISA data model change for different units

### DIFF
--- a/libs/api-clients/CHANGELOG.md
+++ b/libs/api-clients/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.0.1-a.1 (2025-09-23)
+## 0.0.1-a.1 (2025-10-10)
 
-This was a version bump only for api-clients to align it with other projects, there were no code changes.
+- updated the MeasureSeriesMetadata model to include units for the measurement, treatment, and initiated at age.
 
 # Changelog
 

--- a/libs/api-clients/package.json
+++ b/libs/api-clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jax-data-science/api-clients",
-  "version": "0.0.1-a",
+  "version": "0.0.1-a.1",
   "peerDependencies": {
     "@angular/common": "^19.2.14",
     "@angular/core": "^19.2.14",

--- a/libs/api-clients/src/lib/models/isa-data/isa-data.model.ts
+++ b/libs/api-clients/src/lib/models/isa-data/isa-data.model.ts
@@ -46,12 +46,14 @@ export interface MeasureMetadata {
 export interface MeasureSeriesMetadata {
   assay_id: number;
   description: string;
+  initiated_at_units: string;
   measure_ids: string[];
   measure_series_id: string;
+  measurement_units: string;
   method: string;
   study_id?: number;
-  units: string;
   treatment: string;
+  treatment_units: string;
   variable_name: string;
 
   characteristics?: Record<string, string[]>;

--- a/libs/api-clients/src/lib/models/isa-data/isa-data.model.ts
+++ b/libs/api-clients/src/lib/models/isa-data/isa-data.model.ts
@@ -46,7 +46,7 @@ export interface MeasureMetadata {
 export interface MeasureSeriesMetadata {
   assay_id: number;
   description: string;
-  initiated_at_units: string;
+  initiated_at_units?: string;
   measure_ids: string[];
   measure_series_id: string;
   measurement_units: string;


### PR DESCRIPTION
- Made changes to the MeasureSeriesMeta data interface to support units for initiated at age, measurement, and treatment
- measurement_units replaces units