### PR TITLE
add id-token: write to release.yml for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: PUBLISH - NPM
 
 on: [workflow_dispatch]
 
+permissions:
+  id-token: write  # Required for OIDC
+
 jobs:
   test:
     name: Publish


### PR DESCRIPTION
I guess classic npm tokens have been revoked, so I setup OpenID Connect (OIDC) between the npm package and the github repo. Hopefully this resolves the publish issue. 