### PR TITLE
Is 426 packages readme documentation updates

### DIFF
--- a/libs/api-clients/README.md
+++ b/libs/api-clients/README.md
@@ -1,3 +1,141 @@
+## @jax-data-science/api-clients by The Jackson Laboratory (JAX)
+
+# Overview
+The library provides a centralized, standardized approach for frontend applications to interact with 
+backend services across the JAX Data Science ecosystem. It eliminates code duplication by offering reusable 
+API clients with consistent error handling, request/response models, and authentication mechanisms. 
+The library abstracts service communication details and provides orchestration, allowing developers to focus on 
+UI logic without worrying about underlying implementation. It's configurable via Angular injection tokens, 
+handles HTTP and custom errors uniformly, and defines type-safe UI models for robust data handling. 
+
+Designed primarily for component consumption but usable independently, it ensures consistency and 
+maintainability as backend services evolve.
+
+## Installation
+
+```bash
+npm install @jax-data-science/api-clients
+```
+
+## Available API Clients
+
+> **Note**: For a complete list of API clients, visit our [Demo Application](https://jds-apps.jax.org/echo) or check the generated documentation.
+
+## Quick Start
+
+### 1. Set needed service configuration in your application (e.g., base URL, timeout)
+
+```typescript
+/**
+ * app.module.ts
+ */
+
+...
+// MY_SERVICE_CONFIG: injection token used to provide configuration values (like API urls) for MyService
+// MyServiceConfig is an interface that defines the structure of the configuration object
+import { MY_SERVICE_CONFIG, MyServiceConfig } from '@jax-data-science/api-clients';
+...
+
+...
+@NgModule({
+  declarations: [...],
+  ...
+  providers: [
+    {
+      provide(MY_SERVICE_CONFIG, {
+        useValue: {
+          baseUrl: 'https://api.example.com', // could also come from environment variables
+          timeout: 5000, // could also come from environment variables
+        } as MyServiceConfig
+      })
+    }
+  ]
+})
+```
+
+
+### 2. Inject and use the API client in your components or services
+
+```typescript
+
+
+/**
+ * example.component.ts
+ */
+
+import { Component, OnInit } from '@angular/core';
+
+import { MyService } from '@jax-data-science/api-clients';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: './example.component.html',
+  styleUrls: ['./example.component.css']
+})
+
+export class ExampleComponent implements OnInit {
+  data: any;
+
+  // Inject MyService into the component
+  constructor(private myService: MyService) {}
+
+  ngOnInit() {
+    // Use the service to fetch data
+    this.myService.getData().subscribe(
+      (response) => {
+        this.data = response;
+      },
+      (error) => {
+        console.error('Error fetching data:', error);
+      }
+    );
+  }
+}
+```
+
+## Contributing
+The JAX Data Science team welcomes and encourages collaborations!
+
+### Ways to Contribute
+
+- **API Clients Development**
+
+- **Testing & Quality Assurance**
+
+- **Documentation**
+
+- **Bug Fixes & Enhancements**
+
+### Reporting Issues
+
+Found a bug or have a suggestion? Please email us at: npm@jax.org
+
+When reporting issues please include:
+
+- a clear description of the problem or suggestion
+- steps to reproduce (for bugs)
+- expected vs. actual behavior
+- screenshots or code examples when applicable
+- environment details (browser, framework version, etc.)
+
+
+## Changelog
+
+For detailed release notes and version history, see [CHANGELOG.md](./CHANGELOG.md).
+
+## More Information
+
+**GitHub Repo**: [jds-ui-components](https://github.com/TheJacksonLaboratory/jds-ui-components)
+
+**Maintained By**: JAX Data Science
+
+**Contact**: npm@jax.org
+
+**Demo Application**: [View JDS Components](https://jds-apps.jax.org/echo)
+
+
+```bash
+
 # api-clients
 
 This library was generated with [Nx](https://nx.dev).

--- a/libs/components/README.md
+++ b/libs/components/README.md
@@ -2,7 +2,7 @@
 
 # Overview
 This library provides reusable, accessible, and consistent UI components that work seamlessly across
-multiple applications and microforntend architectures. Built with modern web standards, the library ensures
+multiple applications and micro-frontend architectures. Built with modern web standards, the library ensures
 components maintain visual and functional consistency whether used in standalone apps, embedded widgets, or
 federated modules. The library integrates seamlessly with `@jax-data-science/themes` to provide a cohesive
 design system across the entire JAX Data Science community.

--- a/libs/components/README.md
+++ b/libs/components/README.md
@@ -1,6 +1,11 @@
-# @jax-data-science/components
+## @jax-data-science/components by The Jackson Laboratory (JAX)
 
-A comprehensive UI component library built with Angular and designed for JAX Data Science applications. This library was generated with [Nx](https://nx.dev) and provides reusable, accessible, and consistent UI components.
+# Overview
+This library provides reusable, accessible, and consistent UI components that work seamlessly across
+multiple applications and microforntend architectures. Built with modern web standards, the library ensures
+components maintain visual and functional consistency whether used in standalone apps, embedded widgets, or
+federated modules. The library integrates seamlessly with `@jax-data-science/themes` to provide a cohesive
+design system across the entire JAX Data Science community.
 
 ## Installation
 
@@ -8,14 +13,18 @@ A comprehensive UI component library built with Angular and designed for JAX Dat
 npm install @jax-data-science/components @jax-data-science/themes
 ```
 
+## Available Components
+
+> **Note**: For a complete list of components and their APIs, visit our [Demo Application](https://jds-apps.jax.org/echo) or check the generated documentation.
+
+## Theming
+The library supports custom theming through CSS custom properties. See the `@jax-data-science/themes` package
+for available themes and customization options.
+
 ## Quick Start
-
 ### 1. Import Module
-
-Import the required modules in your Angular application:
-
+Import the required modules in your application:
 ```typescript
-
 import { SomeJAXComponent } from '@jax-data-science/components';
 
 @Component({
@@ -25,10 +34,8 @@ export class AppComponent {}
 ```
 
 ### 2. Import Styles
-
 Add the required styles to your `angular.json` file:
-
-```json
+```typescript
 {
   "projects": {
     "your-project-name": {
@@ -36,9 +43,10 @@ Add the required styles to your `angular.json` file:
         "build": {
           "options": {
             "styles": [
+              ...
               "node_modules/@jax-data-science/components/styles/styles.css",
               "node_modules/@jax-data-science/components/styles/components-tailwind.css",
-              "src/styles.css"
+              ...
             ]
           }
         }
@@ -49,9 +57,7 @@ Add the required styles to your `angular.json` file:
 ```
 
 ### 3. Use Components
-
-Start using components in your templates:
-
+Start using components in your templates
 ```html
 <jax-button variant="primary" size="medium">
   Click me
@@ -67,82 +73,51 @@ Start using components in your templates:
 </jax-card>
 ```
 
-## Styling System
-
-### Available Stylesheets
-
-The `@jax-data-science/components` library provides two main stylesheets:
-
-| Stylesheet | Description | Required |
-|-----------|-------------|----------|
-| `styles/styles.css` | Core component styles, themes, and design tokens | ✅ Yes |
-| `styles/components-tailwind.css` | Compiled Tailwind CSS utilities for enhanced styling | ⚠️ Optional |
-
-### Style Import Options
-
-#### Option 1: Angular.json (Recommended)
-Add styles to your `angular.json` configuration:
-
-```json
-{
-  "projects": {
-    "your-project-name": {
-      "architect": {
-        "build": {
-          "options": {
-            "styles": [
-              "node_modules/@jax-data-science/components/styles/styles.css",
-              "node_modules/@jax-data-science/components/styles/components-tailwind.css"
-            ]
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-#### Option 2: Global Styles
-Import in your `src/styles.css` file:
-
-```css
-@import '~@jax-data-science/components/styles/styles.css';
-@import '~@jax-data-science/components/styles/components-tailwind.css';
-```
-
-#### Option 3: Component-level Import
-Import in specific components:
-
-```scss
-// In your component.scss file
-@import '~@jax-data-science/components/styles/styles.css';
-```
-
-### Theming
-
-The library supports custom theming through CSS custom properties. See the `@jax-data-science/themes` package for available themes and customization options.
-
-## Available Components
-
-> **Note**: For a complete list of components and their APIs, visit our [Demo Application](https://jds-apps.jax.org/components) or check the generated documentation.
-
 
 ## Contributing
+The JAX Data Science team welcomes and encourages collaborations!
 
-This library is part of the JAX Data Science UI Components monorepo. For contribution guidelines, please refer to the main repository documentation.
+### Why Contribute?
+By contributing to `@jax-data-science/components`, you help:
+- robust library of reusable components that accelerate development across JAX teams
+- establish consistent user experiences across the JAX Data Science discovery ecosystem
+- advance open science by sharing high-quality UI patterns with the broader research community
+- collaborate with scientists and developers to solve real-world data visualization and interaction challenges
+- shape the future of scientific software interfaces and user experience design
+
+### Ways to Contribute
+
+- **Component Development**
+
+- **Testing & Quality Assurance**
+
+- **Documentation**
+
+- **Bug Fixes & Enhancements**
 
 ### Reporting Issues
-- Create issues in the main repository
-- Provide detailed reproduction steps
-- Include browser and version information
+
+Found a bug or have a suggestion? Please email us at: npm@jax.org
+
+When reporting issues please include:
+
+- a clear description of the problem or suggestion
+- steps to reproduce (for bugs)
+- expected vs. actual behavior
+- screenshots or code examples when applicable
+- environment details (browser, framework version, etc.)
+
 
 ## Changelog
 
-See [CHANGELOG.md](./CHANGELOG.md) for recent updates and version history.
+For detailed release notes and version history, see [CHANGELOG.md](./CHANGELOG.md).
 
+## More Information
 
----
+**GitHub Repo**: [jds-ui-components](https://github.com/TheJacksonLaboratory/jds-ui-components)
 
-**Maintained by**: JAX Data Science UI/UX Team  
-**Repository**: [jds-ui-components](https://github.com/TheJacksonLaboratory/jds-ui-components)  
-**Demo Application**: [View Components](https://jds-apps.jax.org/components)
+**Maintained By**: JAX Data Science
+
+**Contact**: npm@jax.org
+
+**Demo Application**: [View JDS Components](https://jds-apps.jax.org/echo)

--- a/libs/themes/README.md
+++ b/libs/themes/README.md
@@ -1,12 +1,122 @@
-# theme
+## @jax-data-science/themes by The Jackson Laboratory (JAX)
 
-This library was generated with [Nx](https://nx.dev).
+# Overview
+This library's purpose is to provide standardized theming solution for applications and component libraries within
+the JAX Data Science ecosystem. As JAX Data Science builds interconnected apps and shared libraries that
+get embedded into each other through microforntend patterns like module federation, maintaining visual consistency
+becomes critical. The `@jax-data-science/themes` library ensures that components look and behave consistently
+whether they're used as standalone applications, embedded as widgets, or composed through microfrontend
+architectures.
+
+The library provides centralized design tokens, preset themes, and utiities that work seamlessly
+across different frameworks and integration patterns. All themes are built with accessibility as a priority,
+meeting WCAG 2.1 AA standards by default. By using a single source of truth for theming, teams can focus on
+building features while automatically maintaining brand consistency and reducing styling duplication across the
+entire JAX ecosystem.
+
+## Installation
+
+```bash
+npm install @jax-data-science/themes
+```
 
 
-## Building a new theme
-Create a new folder under src/theme/lib with the theme name and add the necessary files. Export this new theme
-in `index.ts`.
+## Available Themes
+Currently, the library includes the **Echo** theme, our flagship preset built on top of PrimeNG's modern style
+**Lara** theme.
 
-## Running unit tests
+**Echo** extends **Lara** with JAX-specific design tokens including custom color palettes,
+typography scales, and spacing systems tailored for data-intensive scientific applications. As the library evolves,
+additional theme presets will be added to support different use cases and branding requirements across The
+Jackson Laboratory's data science ecosystem.
 
-Run `nx test theme` to execute the unit tests.
+## Quick Start
+### 1. Import and Apply the EchoPreset Theme
+
+```typescript
+// app.config.ts
+
+import { EchoPreset } from '@jax-data-science/themes';
+import { providePrimeNG } from 'primeng/config';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    providePrimeNG({
+      theme: {
+        preset: EchoPreset
+      }
+    })
+  ]
+};
+
+```
+
+### 2. Use in Components
+Once configured, all PrimeNG components will automatically use the Echo theme
+```typescript 
+import { Component } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
+
+@Component({
+  selector: 'app-example',
+  standalone: true,
+  imports: [ButtonModule],
+  template: `
+    
+  `
+})
+export class ExampleComponent {}
+```
+
+### 3. Access Theme Variables in CSS
+The Echo theme exposes CSS custom properties that you can use in your styles:
+```css
+.custom-component {
+  background-color: var(--primary-color);
+  color: var(--text-color);
+  border-radius: var(--border-radius);
+}
+```
+
+
+## Contributing
+The JAX Data Science team welcomes and encourages collaborations!
+
+### Why Contribute?
+By contributing to `@jax-data-science/themes`, you help:
+- establish consistent, accessible design patterns across JAX applications, databases and tools
+- build reusable themes that benefit the entire research community
+- improve the developer experience for teams working with JAX platforms
+- advance open science through better data visualization and user interfaces
+
+### Ways to Contribute
+- **Theme Development**
+- **Accessibility Improvements**
+- **Documentation**
+- **Bug Fixes & Enhancements**
+
+### Reporting Issues
+
+Found a bug or have a suggestion? Please email us at: npm@jax.org
+
+When reporting issues please include:
+- a clear description of the problem or suggestion
+- steps to reproduce (for bugs)
+- expected vs. actual behavior
+- screenshots or code examples when applicable
+- environment details (browser, framework version, etc.)
+
+
+## Changelog
+
+For detailed release notes and version history, see [CHANGELOG.md](./CHANGELOG.md).
+
+## More Information
+
+**GitHub Repo**: [jds-ui-components](https://github.com/TheJacksonLaboratory/jds-ui-components)
+
+**Maintained By**: JAX Data Science
+
+**Contact**: npm@jax.org
+
+**Demo Application**: [View Echo Theme](https://jds-apps.jax.org/echo)


### PR DESCRIPTION
JAX Data Science has three published NPM packages that currently lack complete and useful documentation.

- @jax-data-science/components 
- @jax-data-science/themes 
- @jax-data-science/api-clients

These packages are publicly available on NPM but their README files are either incomplete or missing entirely. This creates a poor developer experience for potential users who want to understand what these packages do, how to install them, and how to use them effectively. 

The goal of this task is to create professional, comprehensive README documentation for all three packages that will serve as the primary reference for developers in the public NPM registry.