### PR TITLE
chore: release api-clients@0.1.0-a.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         shell: bash
 
       - name: Publish packages
-        run: pnpm nx release publish --projects=themes,components
+        run: pnpm nx release publish --projects=api-clients
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}

--- a/libs/api-clients/CHANGELOG.md
+++ b/libs/api-clients/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the @jax-data-science/api-clients library will be documen
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0-a.0] - 2026-03-12
+
+### Changed
+- Updated peer dependency from Angular 19 to Angular 20
+- Migrated all `*ngIf` usages to the new built-in `@if` control flow syntax
+- Migrated all `*ngFor` usages to the new built-in `@for` control flow syntax
+- Removed `CommonModule` imports where they were only needed for `NgIf` and `NgFor` directives
+
+---
+
 ## [0.0.2-0] - 2025-12-30
 
 ### Changed

--- a/libs/api-clients/package.json
+++ b/libs/api-clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jax-data-science/api-clients",
-  "version": "0.0.2-0",
+  "version": "0.1.0-a.0",
   "peerDependencies": {
     "@angular/common": "^20.3.0",
     "@angular/core": "^20.3.0",


### PR DESCRIPTION
Changed (api-clients):
- Updated peer dependency from Angular 19 to Angular 20
- Migrated all *ngIf usages to the new built-in @if control flow syntax
- Migrated all *ngFor usages to the new built-in @for control flow syntax
- Removed CommonModule imports where they were only needed for NgIf and NgFor directives